### PR TITLE
Add page preview hover support for similar notes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,14 @@ export default class RelatedNotes extends Plugin {
 					isIgnoredPath: this.appContainer.isIgnoredPath,
 				})
 		);
+		this.registerHoverLinkSource(VIEW_TYPE_SIMILARITY, {
+			display: "Similarity",
+			defaultMod: true,
+		});
+		this.registerHoverLinkSource("similarity-search", {
+			display: "Similarity search",
+			defaultMod: true,
+		});
 
 		this.addCommand({
 			id: "sync-vault",

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,10 +34,6 @@ export default class RelatedNotes extends Plugin {
 			display: "Similarity",
 			defaultMod: true,
 		});
-		this.registerHoverLinkSource("similarity-search", {
-			display: "Similarity search",
-			defaultMod: true,
-		});
 
 		this.addCommand({
 			id: "sync-vault",

--- a/src/ui/SearchModal.ts
+++ b/src/ui/SearchModal.ts
@@ -176,19 +176,6 @@ export class SearchModal extends SuggestModal<RelatedNote> {
 		new Notice("Could not insert link: no active editor.");
 	}
 
-	private triggerHoverPreview(event: MouseEvent, targetEl: HTMLElement, path: string) {
-		const activeFile = this.app.workspace.getActiveFile();
-
-		this.app.workspace.trigger("hover-link", {
-			event,
-			source: "similarity-search",
-			hoverParent: this.resultContainerEl,
-			targetEl,
-			linktext: path,
-			sourcePath: activeFile?.path ?? path,
-		});
-	}
-
 	renderSuggestion(value: RelatedNote, el: HTMLElement): void {
 		let fileName = value.id;
 		if (fileName.endsWith(".md")) fileName = fileName.slice(0, -3);
@@ -196,10 +183,6 @@ export class SearchModal extends SuggestModal<RelatedNote> {
 
 		const titleEl = el.createDiv({text: fileName});
 		titleEl.addClass("internal-link");
-
-		el.addEventListener("mouseover", (event: MouseEvent) => {
-			this.triggerHoverPreview(event, el, value.id);
-		});
 
 		el.createEl("small", {text: `${scorePercent}%`, cls: "suggestion-note"});
 	}

--- a/src/ui/SearchModal.ts
+++ b/src/ui/SearchModal.ts
@@ -176,12 +176,31 @@ export class SearchModal extends SuggestModal<RelatedNote> {
 		new Notice("Could not insert link: no active editor.");
 	}
 
+	private triggerHoverPreview(event: MouseEvent, targetEl: HTMLElement, path: string) {
+		const activeFile = this.app.workspace.getActiveFile();
+
+		this.app.workspace.trigger("hover-link", {
+			event,
+			source: "similarity-search",
+			hoverParent: this.resultContainerEl,
+			targetEl,
+			linktext: path,
+			sourcePath: activeFile?.path ?? path,
+		});
+	}
+
 	renderSuggestion(value: RelatedNote, el: HTMLElement): void {
 		let fileName = value.id;
 		if (fileName.endsWith(".md")) fileName = fileName.slice(0, -3);
 		const scorePercent = (value.score * 100).toFixed(0);
 
-		el.createDiv({text: fileName});
+		const titleEl = el.createDiv({text: fileName});
+		titleEl.addClass("internal-link");
+
+		el.addEventListener("mouseover", (event: MouseEvent) => {
+			this.triggerHoverPreview(event, el, value.id);
+		});
+
 		el.createEl("small", {text: `${scorePercent}%`, cls: "suggestion-note"});
 	}
 

--- a/src/ui/SimilarNotesListView.ts
+++ b/src/ui/SimilarNotesListView.ts
@@ -74,6 +74,19 @@ export class SimilarNotesListView extends ItemView {
 			});
 	};
 
+	private triggerHoverPreview(event: MouseEvent, targetEl: HTMLElement, path: string) {
+		const activeFile = this.app.workspace.getActiveFile();
+
+		this.app.workspace.trigger("hover-link", {
+			event,
+			source: VIEW_TYPE_SIMILARITY,
+			hoverParent: this.containerEl,
+			targetEl,
+			linktext: path,
+			sourcePath: activeFile?.path ?? path,
+		});
+	}
+
 	async onOpen() {
 		this.unsubscribeIndexingState = this.deps.subscribeIndexingState((snapshot) => {
 			const previous = this.indexingState;
@@ -263,6 +276,9 @@ export class SimilarNotesListView extends ItemView {
 				cls: "tree-item-self tag-pane-tag is-clickable",
 			});
 			itemSelf.addEventListener("click", () => this.openNote(path));
+			itemSelf.addEventListener("mouseover", (event: MouseEvent) => {
+				this.triggerHoverPreview(event, itemSelf, path);
+			});
 
 			const itemInner = itemSelf.createDiv({cls: "tree-item-inner"});
 


### PR DESCRIPTION
The side-bar of relevant notes works great, but doesn't yet allow for the native Obisidan hover-over file preview. This is especially useful for journal files which might not have titles that tell you what they contain. 

## Summary

Adds native Obsidian Page Preview support to Similarity results. The Similar notes side panel renders related-note results as custom DOM elements, so Obsidian’s Page Preview core plugin previously did not recognize them as previewable links. This change registers the Similarity UI as a hover-link source and triggers Obsidian’s native `hover-link` event when a related-note result is hovered.

Click behavior is unchanged.

## Changes

- Register the Similar notes view as an Obsidian hover-link source.
- Trigger `hover-link` from related-note items in the right-side Similar notes panel.
- Pass the note’s vault-relative Markdown path as `linktext`, allowing notes in subfolders to resolve correctly.
- Preserve existing click-to-open behavior.
- Add the same hover-preview behavior to semantic search modal suggestions.
- Mark semantic search suggestion titles with `internal-link` styling.

---

Hopelijk vind je dit een goede toevoeging!